### PR TITLE
[FEAT] 태그 모음 보기 구현 

### DIFF
--- a/src/main/java/com/example/FixLog/controller/TagController.java
+++ b/src/main/java/com/example/FixLog/controller/TagController.java
@@ -1,0 +1,22 @@
+package com.example.FixLog.controller;
+
+import com.example.FixLog.dto.Response;
+import com.example.FixLog.dto.tag.TagResponseDto;
+import com.example.FixLog.service.TagService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/tags")
+public class TagController {
+    private final TagService tagService;
+
+    public TagController(TagService tagService){
+        this.tagService = tagService;
+    }
+
+    @GetMapping
+    public Response<Object> viewTags(@RequestParam("page") int page){
+        TagResponseDto tags = tagService.viewTags(page);
+        return Response.success("태그 모아보기 성공", tags);
+    }
+}

--- a/src/main/java/com/example/FixLog/domain/tag/Tag.java
+++ b/src/main/java/com/example/FixLog/domain/tag/Tag.java
@@ -21,10 +21,14 @@ public class Tag {
     @Column(length = 20, nullable = false)
     private String tagName;
 
-    public static Tag of(TagCategory tagCategory, String tagName) {
+    @Column(nullable = false)
+    private String tagInfo;
+
+    public static Tag of(TagCategory tagCategory, String tagName, String tagInfo) {
         Tag tag = new Tag();
         tag.tagCategory = tagCategory;
         tag.tagName = tagName;
+        tag.tagInfo = tagInfo;
         return tag;
     }
 }

--- a/src/main/java/com/example/FixLog/domain/tag/TagCategory.java
+++ b/src/main/java/com/example/FixLog/domain/tag/TagCategory.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum TagCategory {
+    BIG_CATEGORY("분류"),
     MAJOR_CATEGORY("대분류"),
     MIDDLE_CATEGORY("중분류"),
     MINOR_CATEGORY("소분류");

--- a/src/main/java/com/example/FixLog/dto/tag/TagDto.java
+++ b/src/main/java/com/example/FixLog/dto/tag/TagDto.java
@@ -1,0 +1,11 @@
+package com.example.FixLog.dto.tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TagDto {
+    private String tagName;
+    private String tagInfo;
+}

--- a/src/main/java/com/example/FixLog/dto/tag/TagResponseDto.java
+++ b/src/main/java/com/example/FixLog/dto/tag/TagResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.FixLog.dto.tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class TagResponseDto {
+    private List<TagDto> tags;
+    private int totalPages;
+}

--- a/src/main/java/com/example/FixLog/mock/TagTestDataInitializer.java
+++ b/src/main/java/com/example/FixLog/mock/TagTestDataInitializer.java
@@ -19,11 +19,12 @@ public class TagTestDataInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) {
         if (tagRepository.count() == 0) {
-            Tag tag1 = Tag.of(MAJOR_CATEGORY, "101");
-            Tag tag2 = Tag.of(MAJOR_CATEGORY, "101");
-            Tag tag3 = Tag.of(MIDDLE_CATEGORY, "201");
-            Tag tag4 = Tag.of(MINOR_CATEGORY, "301");
-            tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4));
+            Tag tag1 = Tag.of(BIG_CATEGORY, "backend", "백엔드 설명");
+            Tag tag2 = Tag.of(MAJOR_CATEGORY, "springboot", "스프링부트 설명");
+            Tag tag3 = Tag.of(MAJOR_CATEGORY, "django", "장고 설명");
+            Tag tag4 = Tag.of(MIDDLE_CATEGORY, "java", "자바 설명");
+            Tag tag5 = Tag.of(MINOR_CATEGORY, "404 not found", "404 에러 설명");
+            tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4, tag5));
             System.out.println("임시 태그 4개 삽입 완료");
         }
     }

--- a/src/main/java/com/example/FixLog/repository/tag/TagRepository.java
+++ b/src/main/java/com/example/FixLog/repository/tag/TagRepository.java
@@ -1,7 +1,10 @@
 package com.example.FixLog.repository.tag;
 
 import com.example.FixLog.domain.tag.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    Page<Tag> findAll(Pageable pageable);
 }

--- a/src/main/java/com/example/FixLog/service/TagService.java
+++ b/src/main/java/com/example/FixLog/service/TagService.java
@@ -1,0 +1,45 @@
+package com.example.FixLog.service;
+
+import com.example.FixLog.domain.member.Member;
+import com.example.FixLog.domain.tag.Tag;
+import com.example.FixLog.dto.UserIdDto;
+import com.example.FixLog.dto.tag.TagDto;
+import com.example.FixLog.dto.tag.TagResponseDto;
+import com.example.FixLog.exception.CustomException;
+import com.example.FixLog.exception.ErrorCode;
+import com.example.FixLog.repository.MemberRepository;
+import com.example.FixLog.repository.tag.TagRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TagService {
+    private final TagRepository tagRepository;
+
+    public TagService(TagRepository tagRepository){
+        this.tagRepository = tagRepository;
+    }
+
+    // 태그 모음 보기
+    public TagResponseDto viewTags(int page){
+        Pageable pageable = PageRequest.of(page - 1, 12);
+
+        Page<Tag> tags = tagRepository.findAll(pageable);
+
+        List<TagDto> tagList = tags.stream()
+                .map(tag -> new TagDto(
+                        tag.getTagName(),
+                        tag.getTagInfo()
+                ))
+                .collect(Collectors.toList());
+
+        int totalPages = tags.getTotalPages();
+
+        return new TagResponseDto(tagList, totalPages);
+    }
+}


### PR DESCRIPTION
### 이슈 번호
> #39 

### 작업 내용
* 태그 모아보기 api 구현
* 태그 분류에 '분류' enum 추가 
* 태그 설명 관련된 로직 수정

