### PR TITLE
[FIX] 기본 이미지 설정

### DIFF
--- a/src/main/java/com/example/FixLog/dto/post/MyPostPageResponseDto.java
+++ b/src/main/java/com/example/FixLog/dto/post/MyPostPageResponseDto.java
@@ -23,6 +23,13 @@ public class MyPostPageResponseDto {
     private int likeCount;
     private int forkCount;
     private String nickname;
+    private String profileImageUrl;;
+
+    public static String getDefaultImage(String image) {
+        return (image == null || image.isBlank())
+                ? "https://fixlog-bucket.s3.ap-northeast-2.amazonaws.com/default/profile.png"
+                : image;
+    }
 
     public static MyPostPageResponseDto from(Post post, int forkCount) {
         return MyPostPageResponseDto.builder()
@@ -30,7 +37,8 @@ public class MyPostPageResponseDto {
                 .nickname(post.getUserId().getNickname())
                 .postTitle(post.getPostTitle())
                 .postSummary(generateSummary(post.getProblem()))
-                .imageUrl(post.getCoverImage())
+                .imageUrl(getDefaultImage(post.getCoverImage()))
+                .profileImageUrl(getDefaultImage(post.getUserId().getProfileImageUrl()))
                 .tags(post.getPostTags().stream().map(tag -> tag.getTagId().getTagName()).toList())
                 .createdAt(post.getCreatedAt())
                 .likeCount(post.getPostLikes().size())


### PR DESCRIPTION
### 이슈 번호
> #96

### 작업 내용
* 게시글 이미지 null 이면 기본 이미지 설정
* 북마크, 쓴 글, 좋아요 글 작성자 프로필 이미지 응답 추가


### 기타
디자인 수정된거 반영하면서 기본이미지도 설정했습니다! 
MyPostPageResponseDto 부분만 S3관련 설정해서 혹시 수정필요하면 참고해주시면 될 것 같습니다