### PR TITLE
[FIX] 태그 오타, 태그 불러오기 수정(소분류만 불러오도록)

### DIFF
--- a/src/main/java/com/example/FixLog/mock/TagMockDataInitializer.java
+++ b/src/main/java/com/example/FixLog/mock/TagMockDataInitializer.java
@@ -34,7 +34,7 @@ public class TagMockDataInitializer implements CommandLineRunner {
         // BIG_CATEGORY
         addIfNotExist(tagsToInsert, existingTagNames, Tag.of(BIG_CATEGORY, "backend"));
         addIfNotExist(tagsToInsert, existingTagNames, Tag.of(BIG_CATEGORY, "machine-learning"));
-        addIfNotExist(tagsToInsert, existingTagNames, Tag.of(BIG_CATEGORY, "frontend"));
+        addIfNotExist(tagsToInsert, existingTagNames, Tag.of(BIG_CATEGORY, "web"));
 
         // MAJOR_CATEGORY
         addIfNotExist(tagsToInsert, existingTagNames, Tag.of(MAJOR_CATEGORY, "django"));

--- a/src/main/java/com/example/FixLog/repository/tag/TagRepository.java
+++ b/src/main/java/com/example/FixLog/repository/tag/TagRepository.java
@@ -1,6 +1,7 @@
 package com.example.FixLog.repository.tag;
 
 import com.example.FixLog.domain.tag.Tag;
+import com.example.FixLog.domain.tag.TagCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    Page<Tag> findAll(Pageable pageable);
+    // Page<Tag> findAll(Pageable pageable);
+    Page<Tag> findAllByTagCategory(TagCategory tagCategory, Pageable pageable);
     Optional<Tag> findByTagName(String tagName);
 }

--- a/src/main/java/com/example/FixLog/service/TagService.java
+++ b/src/main/java/com/example/FixLog/service/TagService.java
@@ -1,6 +1,7 @@
 package com.example.FixLog.service;
 
 import com.example.FixLog.domain.tag.Tag;
+import com.example.FixLog.domain.tag.TagCategory;
 import com.example.FixLog.dto.tag.TagDto;
 import com.example.FixLog.dto.tag.TagResponseDto;
 import com.example.FixLog.repository.tag.TagRepository;
@@ -24,7 +25,7 @@ public class TagService {
     public TagResponseDto viewTags(int page, int size){
         Pageable pageable = PageRequest.of(page - 1, size);
 
-        Page<Tag> tags = tagRepository.findAll(pageable);
+        Page<Tag> tags = tagRepository.findAllByTagCategory(TagCategory.MINOR_CATEGORY, pageable);
 
         List<TagDto> tagList = tags.stream()
                 .map(tag -> new TagDto(


### PR DESCRIPTION
### 이슈 번호
> 

### 작업 내용
* 태그명 DB랑 통일
* [태그 모음 보기] 소분류(에러명)에 해당하는 태그만 불러오도록
